### PR TITLE
[FIX] Fix product view showing barcode label

### DIFF
--- a/barcodes_generator_product/views/view_product_product.xml
+++ b/barcodes_generator_product/views/view_product_product.xml
@@ -55,7 +55,6 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <field name="barcode" position="replace">
                 <label
                     for="barcode"
-                    groups="barcodes_generator_abstract.generate_barcode"
                 />
                 <div name="div_barcode" class="o_row">
                     <field

--- a/barcodes_generator_product/views/view_product_template.xml
+++ b/barcodes_generator_product/views/view_product_template.xml
@@ -55,7 +55,6 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <field name="barcode" position="replace">
                 <label
                     for="barcode"
-                    groups="barcodes_generator_abstract.generate_barcode"
                     attrs="{'invisible': [('product_variant_count', '&gt;', 1)]}"
                 />
                 <div


### PR DESCRIPTION
This change removes the group from the label. This allows the view to look good with a user without the permisison.